### PR TITLE
:groups and :group are synonymous when specified as a gem option

### DIFF
--- a/lib/gemnasium/parser/gemfile.rb
+++ b/lib/gemnasium/parser/gemfile.rb
@@ -94,8 +94,11 @@ module Gemnasium
         end
 
         def clean!(match, opts)
-          opts["group"] ||= groups(match)
-          groups = Array(opts["group"]).flatten.compact
+          groups = Array(opts.delete('groups') || opts["group"])
+          groups << groups(match)
+          groups = groups.flatten.compact.uniq
+          opts["group"] = groups.any? ? groups : nil # Bundler::Dependency.new does not handle empty "group" option correctly
+
           runtime = groups.empty? || !(groups & Parser.runtime_groups).empty?
           opts["type"] ||= runtime ? :runtime : :development
         end

--- a/spec/gemnasium/parser/gemfile_spec.rb
+++ b/spec/gemnasium/parser/gemfile_spec.rb
@@ -110,6 +110,9 @@ describe Gemnasium::Parser::Gemfile do
   it "parses gems of multiple groups" do
     content(%(gem "rake", :group => [:development, :test]))
     dependency.groups.should == [:development, :test]
+    reset
+    content(%(gem "rake", :groups => [:development, :test]))
+    dependency.groups.should == [:development, :test]
   end
 
   it "parses gems in a group" do


### PR DESCRIPTION
Gemfile allows describing groups in one of the following ways:

`gem 'rake', :group => [:development, :test]`
OR
`gem 'rake', :groups => [:development, :test]`

This patch adds support for parsing :groups as being synonymous to :group.
