### PR TITLE
gemfile_spec properly undents content.

### DIFF
--- a/spec/gemnasium/parser/gemfile_spec.rb
+++ b/spec/gemnasium/parser/gemfile_spec.rb
@@ -1,12 +1,14 @@
 require "spec_helper"
 
 describe Gemnasium::Parser::Gemfile do
+
+  def undent(string)
+    first_line_indent = string[/\A\s*/]
+    string.gsub(/^#{first_line_indent}/, "")
+  end
+
   def content(string)
-    @content ||= begin
-      indent = string.scan(/^[ \t]*(?=\S)/)
-      n = indent ? indent.size : 0
-      string.gsub(/^[ \t]{#{n}}/, "")
-    end
+    @content ||= undent(string)
   end
 
   def gemfile


### PR DESCRIPTION
Content produced by heredoc in the gemfile spec was not being properly undented.  No tests
were broken (the regular expressions are tolerant of leading space),
but it still seems like a good idea to undent the content.
